### PR TITLE
Avoid SSRF for claimed_id request

### DIFF
--- a/lib/openid/consumer/idres.rb
+++ b/lib/openid/consumer/idres.rb
@@ -72,9 +72,9 @@ module OpenID
       def id_res
         check_for_fields
         verify_return_to
-        verify_discovery_results
         check_signature
         check_nonce
+        verify_discovery_results
       end
 
       def server_url


### PR DESCRIPTION
`verify_discovery_results` sends a request to openid.claimed_id URL.
Anybody can change claimed_id URL but request still will be sent. 
For example, sending a request to the internal network or localhost:
https://myserver/callback?_method=post&openid.claimed_id=http://localhost:3000/do_method.....

I think, we must check signature before use any data from the URL